### PR TITLE
Use std::fstream instead of boost::filesystem::fstream

### DIFF
--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -31,7 +31,7 @@ void OfflineUpdateFetcher::fetchRole(std::string* result, int64_t maxsize, Repos
     throw Uptane::MetadataFetchFailure(repo.ToString(), path.string());
   }
 
-  boost::filesystem::ifstream file_input(path);
+  std::ifstream file_input(path.c_str());
   file_input.seekg(0, file_input.end);
   int64_t file_size = file_input.tellg();
   // [OFFUPD] Maybe throw a better error here?


### PR DESCRIPTION
`boost::filesystem::fstream` no longer exists