### PR TITLE
bootloader: add grub_generic rollback mode

### DIFF
--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -167,7 +167,7 @@ struct TelemetryConfig {
   void writeToStream(std::ostream& out_stream) const;
 };
 
-enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked };
+enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked, kGrubGeneric };
 std::ostream& operator<<(std::ostream& os, RollbackMode mode);
 
 struct BootloaderConfig {
@@ -175,6 +175,7 @@ struct BootloaderConfig {
   boost::filesystem::path reboot_sentinel_dir{"/var/run/aktualizr-session"};
   boost::filesystem::path reboot_sentinel_name{"need_reboot"};
   std::string reboot_command{"/sbin/reboot"};
+  boost::filesystem::path grub_envfile{"/media/efi/EFI/BOOT/grubenv"};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -42,6 +42,19 @@ void Bootloader::setBootOK() const {
         LOG_WARNING << "Failed resetting upgrade_available for u-boot";
       }
       break;
+    case RollbackMode::kGrubGeneric: {
+        const std::string env = config_.grub_envfile.string();
+        if (Utils::shell("grub-editenv " + env + " set bootcount=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting bootcount via grub-editenv";
+        }
+        if (Utils::shell("grub-editenv " + env + " set upgrade_available=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting upgrade_available via grub-editenv";
+        }
+        if (Utils::shell("grub-editenv " + env + " set rollback=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting rollback via grub-editenv";
+        }
+      }
+      break;
     default:
       throw NotImplementedException();
   }
@@ -69,6 +82,22 @@ void Bootloader::updateNotify() const {
       }
       if (Utils::shell("fw_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";
+      }
+      break;
+    case RollbackMode::kGrubGeneric: {
+        const std::string env = config_.grub_envfile.string();
+        if (Utils::shell("grub-editenv " + env + " set bootcount=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting bootcount via grub-editenv";
+        }
+        if (Utils::shell("grub-editenv " + env + " set upgrade_available=1", &sink) != 0) {
+          LOG_WARNING << "Failed setting upgrade_available via grub-editenv";
+        }
+        if (Utils::shell("grub-editenv " + env + " set rollback=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting rollback via grub-editenv";
+        }
+        if (Utils::shell("grub-editenv " + env + " set default=0", &sink) != 0) {
+          LOG_WARNING << "Failed resetting default via grub-editenv";
+        }
       }
       break;
     default:

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -10,6 +10,9 @@ std::ostream& operator<<(std::ostream& os, RollbackMode mode) {
     case RollbackMode::kUbootMasked:
       mode_s = "uboot_masked";
       break;
+    case RollbackMode::kGrubGeneric:
+      mode_s = "grub_generic";
+      break;
     default:
       mode_s = "none";
       break;
@@ -27,6 +30,8 @@ inline void CopyFromConfig(RollbackMode& dest, const std::string& option_name, c
       dest = RollbackMode::kUbootGeneric;
     } else if (mode == "uboot_masked") {
       dest = RollbackMode::kUbootMasked;
+    } else if (mode == "grub_generic") {
+      dest = RollbackMode::kGrubGeneric;
     } else {
       dest = RollbackMode::kBootloaderNone;
     }
@@ -38,6 +43,7 @@ void BootloaderConfig::updateFromPropertyTree(const boost::property_tree::ptree&
   CopyFromConfig(reboot_sentinel_dir, "reboot_sentinel_dir", pt);
   CopyFromConfig(reboot_sentinel_name, "reboot_sentinel_name", pt);
   CopyFromConfig(reboot_command, "reboot_command", pt);
+  CopyFromConfig(grub_envfile, "grub_envfile", pt);
 }
 
 void BootloaderConfig::writeToStream(std::ostream& out_stream) const {
@@ -45,4 +51,5 @@ void BootloaderConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, reboot_sentinel_dir, "reboot_sentinel_dir");
   writeOption(out_stream, reboot_sentinel_name, "reboot_sentinel_name");
   writeOption(out_stream, reboot_command, "reboot_command");
+  writeOption(out_stream, grub_envfile, "grub_envfile");
 }


### PR DESCRIPTION
Adds a RollbackMode::kGrubGeneric backend that drives grubenv via grub-editenv. On x86 grub-efi platforms, Torizon's grub-ota-fallback script under /etc/ostree-grub.d/99_fallback_logic implements bootcount/rollback/upgrade_available logic in GRUB, but aktualizr previously had no way to set those vars. A single failed deployment left rollback=1 stuck in grubenv and every subsequent update was silently rolled back at the GRUB stage without ever attempting the new deployment.